### PR TITLE
Fix: NPM Packaging (Part II)

### DIFF
--- a/package-global.json
+++ b/package-global.json
@@ -1,5 +1,5 @@
 {
-  "name": "@elide/framework",
+  "name": "elide-framework",
   "version": "1.0.0-alpha1",
   "description": "verb. to omit (a sound or syllable) when speaking. to join together; to merge.",
   "repository": {


### PR DESCRIPTION
This changeset uses a fully-global NPM package name, which should hopefully avoid triggering any private package errors.